### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  # before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:show, :index]
   # before_action :set_item, only: [:show, :edit, :update, :destroy,]
 
   def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  # before_action :authenticate_user!, except: [:index]
   # before_action :set_item, only: [:show, :edit, :update, :destroy,]
 
   def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,9 +19,9 @@ class ItemsController < ApplicationController
     end 
   end 
   
-  # def show
-  #   @item = Item.find(params[:id])
-  # end
+  def show
+    @item = Item.find(params[:id])
+  end
 
   # def update
   #   if @item.update(item_params)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -138,9 +138,9 @@
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <%# <% if item.orders.present? %>     
-          <div class='sold-out'>
+          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>    
+          </div>     %>
           <%# <% end %> 
           <%# //商品が売れていればsold outを表示しましょう %>
         <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
       <% if @items.present? %>
       <% @items.each do |item| %>
           <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,16 +134,15 @@
         <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
+
+
           <%# 商品が売れていればsold outを表示しましょう %>
-          <%# <% if item.orders.present? %> 
+          <%# <% if item.orders.present? %>     
           <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
-          
-          
+          </div>    
+          <%# <% end %> 
           <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
         <div class='item-info'>
           <h3 class='item-name'>
             <%= item.name %>
@@ -161,9 +160,7 @@
         </li>
         <% end %>
       
-
       <% else %>
-      
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,72 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# <% if @item.orders.present? %> 
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
+      <%# <% end %> 
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shopping_cost.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# <% if @item.orders.blank? %> 
+      <% if user_signed_in? && current_user.id == @item.user_id %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "商品の編集", edit_item_path(@item[:id]), method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", item_path, method: :delete, class:"item-destroy" %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+      <% else%>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to "購入画面に進む", item_order_path(@item[:id]) ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+    <%# <% end %> 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shopping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shopping_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -103,7 +109,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,11 +31,11 @@
 
       <%= link_to "商品の編集", edit_item_path(@item[:id]), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", item_path, method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
 
       <% else%>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <%= link_to "購入画面に進む", item_order_path(@item[:id]) ,class:"item-red-btn"%>
+      <%# <%= link_to "購入画面に進む", item_orders_path(@item[:id]) ,class:"item-red-btn"%> 
       <%# //商品が売れていない場合はこちらを表示しましょう %>
       <% end %>
     <%# <% end %> 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,9 +10,9 @@
       <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <%# <% if @item.orders.present? %> 
-      <div class="sold-out">
+      <%# <div class="sold-out">
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# <% end %> 
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
@@ -35,7 +35,7 @@
 
       <% else%>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <%# <%= link_to "購入画面に進む", item_orders_path(@item[:id]) ,class:"item-red-btn"%> 
+      <%= link_to '購入画面に進む', item_path(@item.id) ,class:"item-red-btn" %> 
       <%# //商品が売れていない場合はこちらを表示しましょう %>
       <% end %>
     <%# <% end %> 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,18 +27,19 @@
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <%# <% if @item.orders.blank? %> 
-      <% if user_signed_in? && current_user.id == @item.user_id %>
+      <% if user_signed_in? %>
+    <% if current_user.id == @item.user_id %>
 
       <%= link_to "商品の編集", edit_item_path(@item[:id]), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
 
-      <% else%>
+      <% else %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to '購入画面に進む', item_path(@item.id) ,class:"item-red-btn" %> 
       <%# //商品が売れていない場合はこちらを表示しましょう %>
       <% end %>
-    <%# <% end %> 
+    <<% end %> 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <%# <% if @item.orders.blank? %> 
       <% if user_signed_in? %>
     <% if current_user.id == @item.user_id %>
@@ -39,9 +38,8 @@
       <%= link_to '購入画面に進む', item_path(@item.id) ,class:"item-red-btn" %> 
       <%# //商品が売れていない場合はこちらを表示しましょう %>
       <% end %>
-    <<% end %> 
+    <% end %> 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -109,9 +107,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root "items#index"
   resources :items do
-    resources :comments, only: [:create, :destroy, :show, :index] 
+    resources :items, only: [:create, :destroy, :show, :index] 
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root "items#index"
   resources :items do
-    resources :items, only: [:create, :destroy, :show, :index] 
+    resources :comments, only: [:create, :destroy, :show, :index] 
   end
 end


### PR DESCRIPTION
# What
商品詳細表示機能の実装

# Why
商品詳細情報から詳細な情報を確認したり購入画面へ進むため

[ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画](https://gyazo.com/a56f28e14cc1707a1f11d8886fc23196)

[ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画](https://gyazo.com/edbc22c906704061cf50b86eb6b5ae99)

[ログアウト状態で、商品詳細ページへ遷移した動画](https://gyazo.com/be7e19d715271d636de95982ff118338)