### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,7 +37,7 @@ class ItemsController < ApplicationController
 
   def destroy
     if @item.destroy
-      redirect_to root_path
+      redirect_to root_path unless current_user.id == @item.user_id
     else
       redirect :show
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,9 +35,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.user_id == current_user.id && @item.destroy
-      redirect_to root_path
-    else
+  if @item.user_id == current_user.id
+    @item.destroy
+    redirect_to root_path
+  else
       redirect :show
     end
   end
@@ -51,8 +52,8 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
-
 end
+
 
   
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,10 +34,9 @@ class ItemsController < ApplicationController
     end
   end
 
-
   def destroy
-    if @item.destroy
-      redirect_to root_path unless current_user.id == @item.user_id
+    if @item.user_id == current_user.id && @item.destroy
+      redirect_to root_path
     else
       redirect :show
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,13 +35,13 @@ class ItemsController < ApplicationController
   end
 
 
-  # def destroy
-  #   if @item.destroy
-  #     redirect_to root_path
-  #   else
-  #     redirect :show
-  #   end
-  # end
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      redirect :show
+    end
+  end
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
 
       <%= link_to "商品の編集", edit_item_path(@item[:id]), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      
+      <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
 
       <% else %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
 
       <%= link_to "商品の編集", edit_item_path(@item[:id]), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
+      
 
       <% else %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>


### PR DESCRIPTION
# What
商品削除機能の実装

# Why
出品した商品を削除するために必要なため

[ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画](https://gyazo.com/6816ff5faad28dd7e8dc24c29e40957e)